### PR TITLE
boolean 타입 prop의 optional 여부에 따른 사용성 테스트

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
+import Router from 'common/components/Router';
+
 function App() {
-  return <div>주엉아 이번 프로젝트도 아자아자!</div>;
+  return <Router />;
 }
 
 export default App;

--- a/src/boolean-type-prop-optional/OptionalChild.tsx
+++ b/src/boolean-type-prop-optional/OptionalChild.tsx
@@ -1,0 +1,12 @@
+import * as S from './style';
+
+interface OptionalChildProps {
+  isRed?: boolean;
+  content: string;
+}
+
+export default function OptionalChild(props: OptionalChildProps) {
+  const { isRed = false, content } = props;
+  console.log(content, isRed);
+  return <S.Container isRed={isRed}>{content}</S.Container>;
+}

--- a/src/boolean-type-prop-optional/Parent.tsx
+++ b/src/boolean-type-prop-optional/Parent.tsx
@@ -1,0 +1,20 @@
+import OptionalChild from './OptionalChild';
+import RequiredChild from './RequiredChild';
+
+export default function Parent() {
+  return (
+    <div>
+      <section>
+        <h1>Required</h1>
+        {/* Required이어도 ={true}는 생략 가능 */}
+        <RequiredChild isRed={true} content="true" />
+        <RequiredChild isRed={false} content="false" />
+      </section>
+      <section>
+        <h1>Optional</h1>
+        <OptionalChild isRed content="true" />
+        <OptionalChild content="false" />
+      </section>
+    </div>
+  );
+}

--- a/src/boolean-type-prop-optional/RequiredChild.tsx
+++ b/src/boolean-type-prop-optional/RequiredChild.tsx
@@ -1,0 +1,12 @@
+import * as S from './style';
+
+interface RequiredChildProps {
+  isRed: boolean;
+  content: string;
+}
+
+export default function RequiredChild(props: RequiredChildProps) {
+  const { isRed, content } = props;
+  console.log(content, isRed);
+  return <S.Container isRed={isRed}>{content}</S.Container>;
+}

--- a/src/boolean-type-prop-optional/index.tsx
+++ b/src/boolean-type-prop-optional/index.tsx
@@ -1,0 +1,5 @@
+import Parent from './Parent';
+
+export default function BooleanTypePropOptional() {
+  return <Parent />;
+}

--- a/src/boolean-type-prop-optional/style.ts
+++ b/src/boolean-type-prop-optional/style.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const Container = styled.article<{ isRed: boolean }>`
+  background-color: ${(props) => (props.isRed ? 'red' : 'white')};
+`;

--- a/src/common/components/Router.tsx
+++ b/src/common/components/Router.tsx
@@ -1,0 +1,12 @@
+import BooleanTypePropOptional from 'boolean-type-prop-optional';
+import { Routes, Route, BrowserRouter } from 'react-router-dom';
+
+export default function Router() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/boolean-type-prop-optional" element={<BooleanTypePropOptional />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/src/common/components/Router.tsx
+++ b/src/common/components/Router.tsx
@@ -1,10 +1,12 @@
 import BooleanTypePropOptional from 'boolean-type-prop-optional';
+import Home from 'home';
 import { Routes, Route, BrowserRouter } from 'react-router-dom';
 
 export default function Router() {
   return (
     <BrowserRouter>
       <Routes>
+        <Route path="/" element={<Home />} />
         <Route path="/boolean-type-prop-optional" element={<BooleanTypePropOptional />} />
       </Routes>
     </BrowserRouter>

--- a/src/home/index.tsx
+++ b/src/home/index.tsx
@@ -1,0 +1,13 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function Home() {
+  const navigate = useNavigate();
+  return (
+    <div>
+      <h1>Hello 주영이의 React World</h1>
+      <button onClick={() => navigate('/boolean-type-prop-optional')}>
+        boolean type prop의 optional 여부에 따른 사용성 테스트
+      </button>
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -18,9 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "./src"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
- close #3 
# 알고 싶었던 것
### 1. React Componet의 boolean 타입 prop도 html과 같이 선언만으로 true/false 여부를 표현할 수 있는지
```html
<script src="src/main.js" defer></script>
```
html 공부했을 때 boolean 타입 prop(ex script 태그의 defer)은 선언 여부에 따라 값을 줄 수 있다고 배웠다.
그러나 react에서는 그런 식으로 boolean 타입 prop을 사용해본 적이 없는 것 같아 확실히 알고 싶었다.

### 2. 1번이 맞다면, boolean 타입 prop을 optional로 두어야만 가능한 것인지

### 3. 2번이 맞다면, boolean 타입 prop을 optional로 두었을 때와 그렇지 않을 때의 사용성 비교

# 알게 된 것
### 1. React Componet의 boolean 타입 prop도 html과 같이 선언만으로 true/false 여부를 표현할 수 있는지
=> O
boolean 타입 prop을 선언만 하고 그 값을 console에서 확인해보니 true로 나왔다.
```tsx
function Parent() {
  return (
    <div>
      <section>
        <h1>Optional</h1>
        <OptionalChild isRed content="true" />
        <OptionalChild content="false" />
      </section>
    </div>
  );
}

function OptionalChild(props: OptionalChildProps) {
  const { isRed = false, content } = props;
  console.log(content, isRed);
  return <S.Container isRed={isRed}>{content}</S.Container>;
}
```
<img width="670" alt="image" src="https://user-images.githubusercontent.com/73823388/184178998-2f52f8a8-42c1-4774-974a-e86ee684d784.png">

### 2. 1번이 맞다면, boolean 타입 prop을 optional로 두어야만 가능한 것인지
=> O
사실 TypeScriprt 문법 관점에서 당연함.

따라서 OptionalChild에서는 기본 값으로 false를 주었음.
```tsx
function OptionalChild(props: OptionalChildProps) {
  const { isRed = false, content } = props;
  console.log(content, isRed);
  return <S.Container isRed={isRed}>{content}</S.Container>;
}
```

### 3. 2번이 맞다면, boolean 타입 prop을 optional로 두었을 때와 그렇지 않을 때의 사용성 비교
```tsx
export default function Parent() {
  return (
    <div>
      <section>
        <h1>Required</h1>
        {/* Required이어도 ={true}는 생략 가능 */}
        <RequiredChild isRed={true} content="true" />
        <RequiredChild isRed={false} content="false" />
      </section>
      <section>
        <h1>Optional</h1>
        <OptionalChild isRed content="true" />
        <OptionalChild content="false" />
      </section>
    </div>
  );
}
```
확실히 optional로 두는 것이 딱 봐도 편리하고 보기에도 좋다.

하지만 일반적으로는 false 값이지만 특별한 경우에만 true인 경우일 때만 사용해야 할 것 같다.
또한, 굉장히 크리티컬한 값인 경우에도 안될 것 같다.
컴포넌트 사용자 입장에서 true를 주어야 하는지에 대한 고민이 필수적인 prop은 required를 주어 노티를 주는 것이 맞다고 생각한다.

즉, 이번에 사용한 예시처럼, 그저 특수한 스타일을 지정하기 위한 boolean 타입 prop 정도에만 optional을 주면 된다고 생각한다.